### PR TITLE
SaveArbitraryDocuments fails due to Json stream being in invalid state

### DIFF
--- a/Tests/CouchTest.cs
+++ b/Tests/CouchTest.cs
@@ -230,6 +230,21 @@ namespace Divan.Test
         }
 
         [Test]
+        public void ShouldSaveArbitraryDocuments()
+        {
+            var littleCar1 = new LittleCar { docType = "car", Make = "Make1" };
+            var littleCar2 = new LittleCar { docType = "car", Make = "Make2" };
+            var docs = new List<LittleCar> { littleCar1, littleCar2 };
+
+            db.SaveArbitraryDocuments(docs, true);
+            var documentIds = db.GetAllDocuments().Select(doc => doc.Id);
+            var loadedCars = db.GetArbitraryDocuments(documentIds, () => new LittleCar());
+            
+            Assert.AreEqual(littleCar1.Make, loadedCars.ElementAt(0).Make);
+            Assert.AreEqual(littleCar2.Make, loadedCars.ElementAt(1).Make);
+        }
+
+        [Test]
         public void ShouldLoadArbitraryDocument()
         {
             var firstCar = new LittleCar() { docType = "car", Make = "Yugo", Model = "Hell if i know" };

--- a/src/CouchBulkDocuments.cs
+++ b/src/CouchBulkDocuments.cs
@@ -31,9 +31,16 @@ namespace Divan
             writer.WriteStartArray();
             foreach (ICouchDocument doc in Docs)
             {
-                writer.WriteStartObject();
-                doc.WriteJson(writer);
-                writer.WriteEndObject();
+                if (doc is ISelfContained)
+                {
+                    doc.WriteJson(writer);
+                }
+                else
+                {
+                    writer.WriteStartObject();
+                    doc.WriteJson(writer);
+                    writer.WriteEndObject();
+                }
             }
             writer.WriteEndArray();
         }


### PR DESCRIPTION
Hi there,

I've found a problem with Divan with SaveArbitraryDocuments. Basically, it doesn't work because when CouchBulkDocuments writes itself out, it always assumes that its contained objects are not ISelfContained, and so always wraps their writes with a StartObject/EndObject.  This fails for SaveArbitraryDocuments as that works with CouchDocumentWrapper, which does implement ISelfContained.

I've added a unit test, and popped a fix in. If it looks right, do feel free to pull the change in.

Cheers,
 Royston.
